### PR TITLE
Listar requisitos no Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,6 +10,12 @@ O módulo recartDGT é uma aplicação informática, que funciona a partir do QG
 - Conversão da Informação Geográfica (adquirida ao abrigo das normas CartTop) para outros formatos (GPKG, SHP e GeoJSON)
 - Conversão da Informação Geográfica antiga (produzida usando o modelo numérico, multicodificada, em DGN/DWG) para CartTop
 
+#### Requisitos
+
+- O módulo deve ser instalado numa versão do QGIS 3.x (lançado em 2018)
+- A extensão PostGIS deve ser 3.x (lançado em 2019)
+- O servidor PostgreSQL deve estar na versão 11 ou superior (lançado em 2018)
+
 #### Descarregar o plugin recartDGT
 
 O módulo recartDGT está disponível em [recartDGT.zip](https://github.com/dgterritorio/recart-plugin/raw/main/plugin/recartDGT.zip). 
@@ -17,8 +23,6 @@ O módulo recartDGT está disponível em [recartDGT.zip](https://github.com/dgte
 No [repositório do recart](https://github.com/dgterritorio/recart-plugin) está disponível o código fonte. Pode-se e deve-se usar o repositório para reportar questões.
 
 #### Instalar o plugin (interface em Português)
-
-O módulo deve ser instalado numa versão do QGIS 3.x. 
 
 Para instalar o módulo, escolhe-se no menu a opção Módulos → Gerir e instalar módulos...
 1. Escolher "Instalar de um ZIP"

--- a/plugin/validation_rules.sql
+++ b/plugin/validation_rules.sql
@@ -173,7 +173,7 @@ where pc.identificador = bad.identificador $$);
 
 -- "Transportes" NoTransRodov <-> SegViaRodov
 -- "Transportes" NoTransFerrov <-> SegViaFerrea
--- "Hidrografia" os nós hifdrográficos têm que coincidir com eixos de água
+-- "Hidrografia" os nós hidrográficos têm que coincidir com eixos de água
 -- "Construções" só tem a entidade 3D SinalGeodesico, sem ter que ser coincidente com nada.
 delete from validation.rules where code = 'rg_4_2_1';
 insert into validation.rules ( code, name, rule, scope, entity,  query, query_nd2, report ) 


### PR DESCRIPTION
Melhorar a documentação, listando os requisitos no Readme.

Evita-se assim a instalação e reporte de erros em ambientes que não cumpram os requisitos.