### PR TITLE
Conversão de cell headers de DGN/DGNv8: permitir aproveitar só a origem

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -94,13 +94,22 @@ Com esta opção ativada, o módulo tenta ajustar a dimensão da geometria origi
 
 Com esta opção ativada, o módulo tenta correr um algoritmo de **poligonização** de linhas. Por exemplo, se uma construção estiver como linha, tenta-se formar um polígono com as linhas das geometrias originais.
 
-#### Associar código desconhecidos a códigos existentes
+
+#### Aproveitar apenas a origem das células CAD
+
+Na cartografia DGN, se estiverem a ser utilizados elementos "cell headers", todos os elementos gráficos que compoõem esse "cell header" são convertidos para elementos distintos. 
+
+Ativando a opção **Aproveitar apenas origem células CAD** só é criado um elemento do tipo POINT para cada "cell header". As coordenadas do ponto referem-se à origem (ponto de inserção) do "cell header". 
+
+Esta possibilidade depende de uma versão do GDAL >= 3.5. Pode-se usar uma versão compilada, que inclua o [PR#5664](https://github.com/OSGeo/gdal/pull/5664).
+
+#### Associar códigos desconhecidos a códigos existentes
 
 Na conversão de cartografia, podem surgir códigos nos DGN/DWG desconhecidos. 
 
 Os códigos desconhecidos podem ser tratados de duas formas:
 1. A forma mais complexa consiste em acrescentar novos mapeamentos para esses códigos desconhecidos, há semelhança dos muitos mapeamentos existentes. Para tal, é preciso editar o `plugin/convert/mapping.py`.
-2. A forma mais simples consiste em mapear os códigos desconhecidos em códigos conhecidos. Isso faz-se criando um ficheiro de __alias p/ códigos__, que depois é indicado na correspondente opção no plugin.
+2. A forma alternativa consiste em mapear os códigos desconhecidos em códigos conhecidos. Isso faz-se criando um ficheiro de __alias p/ códigos__. Esse ficheiro tem que ser escolhido na correspondente opção no plugin.
 
 ##### Alias p/ Códigos
 

--- a/plugin/convert/gm_cart_import.py
+++ b/plugin/convert/gm_cart_import.py
@@ -29,6 +29,7 @@ class CartImporter:
         self.alias_file = kwargs.get('alias', None)
         self.force_geom = kwargs.get('force_geom', False)
         self.force_polygon = kwargs.get('force_polygon', False)
+        self.cell_headers_origin = kwargs.get('cell_headers_origin', False)
         self.force_close = kwargs.get('force_close', False)
         self.use_layerName = kwargs.get('use_layerName', False)
 
@@ -45,6 +46,7 @@ class CartImporter:
         self.layers = []
 
         os.environ["DGN_ULINK_TYPE"] = self.ulink_type
+        os.environ["DGN_CELL_HEADER_ORIGIN"] = "YES" if self.cell_headers_origin else "NO"
         self.valid_extensions = ['.dgn', '.top', '.shp', '.dwg']
         self.schema = kwargs.get('schema', 'import')
         self.save_src = True
@@ -428,7 +430,7 @@ class CartImporter:
         )
 
         prst_handler = PostgisImporter(
-            self.schema, self.base, self.mapping, self.cod_field, self.ndd, self.force_geom, self.force_polygon, self.force_close, self.use_layerName, self.save_src, self.writer, self.srsid)
+            self.schema, self.base, self.mapping, self.cod_field, self.ndd, self.force_geom, self.force_polygon, self.cell_headers_origin, self.force_close, self.use_layerName, self.save_src, self.writer, self.srsid)
 
         prst_handler.save_styles(os.path.join(bp, pf + '_layer_styles.sql'))
         prst_handler.save_datasource(os.path.join(bp, pf + '_features.sql'))

--- a/plugin/convert/gm_cart_postgis.py
+++ b/plugin/convert/gm_cart_postgis.py
@@ -8,7 +8,7 @@ from . import gm_cart_aux as aux
 class PostgisImporter:
     """Importador de cartografia"""
 
-    def __init__(self, schema, base, mapping, cod_field, ndd, forceGeom, forcePolygon, forceClose, use_layerName, save_src, writer, srsid):
+    def __init__(self, schema, base, mapping, cod_field, ndd, forceGeom, forcePolygon, forceClose, cellHeaderOrigin, use_layerName, save_src, writer, srsid):
         self.schema = schema
         self.base = base
         self.mapping = mapping
@@ -16,6 +16,7 @@ class PostgisImporter:
         self.ndd = ndd
         self.forceGeom = forceGeom
         self.forcePolygon = forcePolygon
+        self.cellHeaderOrigin = cellHeaderOrigin
         self.forceClose = forceClose
         self.writer = writer
 

--- a/plugin/convert/gm_cart_postgis.py
+++ b/plugin/convert/gm_cart_postgis.py
@@ -155,6 +155,9 @@ class PostgisImporter:
             auxtable = True
             geom_type = 'polygon'
 
+        if feature.GetGeometryRef().IsEmpty():
+            return (None, auxtable, {'type': 'Geometry type', 'msg': 'Geometry is empty'})
+
         if geom_type.lower() in layer.geom_type.lower() or not enforce:
             if self.forceGeom and layer.is_3D() and not is_3D\
                     and not layer.name.startswith('_skipped') and not layer.name.startswith('_import_error'):
@@ -459,8 +462,10 @@ class PostgisImporter:
                                     first = False
                                 feat_sql_file.write(cfeat)
                                 feat_sql_file.write('\n')
-                            else:
+                            elif not feat['data'].GetGeometryRef().IsEmpty():
                                 self.base['_import_error'].add_element(feat)
+                            else:
+                                print("Empty geometry")
 
                         feat_sql_file.write(';\n')
         except Exception as e:
@@ -520,6 +525,10 @@ class PostgisImporter:
                             # print(feature['data'].GetFieldAsString('ulink'))
                             # print(feature['data'].GetGeometryRef().GetGeometryType())
                             # print(aux.OGRwkbGeomTypes[feature['data'].GetGeometryRef().GetGeometryType()])
+
+                            if feature['data'].GetGeometryRef().IsEmpty():
+                                continue
+
                             if not first:
                                 remaining_sql_file.write(', ')
                             else:

--- a/plugin/convert_dialog.py
+++ b/plugin/convert_dialog.py
@@ -229,7 +229,7 @@ class ConvertDialog(QDialog, FORM_CLASS):
             kwargs['force_geom'] = self.forceGeomCheckBox.isChecked()
             kwargs['force_polygon'] = self.forcePolygonCheckBox.isChecked()
             kwargs['force_close'] = self.forceCloseCheckBox.isChecked()
-
+            kwargs['cell_headers_origin'] = self.cellHeaderOrigin.isChecked()
             kwargs['use_layerName'] = self.overwriteLNCheckBox.isChecked()
 
             kwargs['schema'] = self.lineEdit.text()

--- a/plugin/development.md
+++ b/plugin/development.md
@@ -4,7 +4,7 @@ The following steps can be used to setup the project for testing and developing:
 
 ### Development dependencies
 
-The following software is needed to develop and build the puglin
+The following software is needed to develop and build the plugin
 ```
 apt install qttools5-dev-tools
 ```

--- a/plugin/ui/convert_dialog.ui
+++ b/plugin/ui/convert_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>830</width>
-    <height>720</height>
+    <height>781</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -90,6 +90,30 @@
             <string>Opções de conversão</string>
            </property>
            <layout class="QGridLayout" name="gridLayout_2">
+            <item row="1" column="0" colspan="3">
+             <widget class="QCheckBox" name="forceGeomCheckBox">
+              <property name="text">
+               <string>Forçar dimensões geometria</string>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="0">
+             <widget class="QCheckBox" name="overwriteLNCheckBox">
+              <property name="text">
+               <string>Mapear com nome camada</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="2">
+             <widget class="QComboBox" name="fieldsComboBox"/>
+            </item>
+            <item row="6" column="0">
+             <widget class="QCheckBox" name="cmapCheckBox">
+              <property name="text">
+               <string>Mapeamento personalizado</string>
+              </property>
+             </widget>
+            </item>
             <item row="0" column="0">
              <widget class="QLabel" name="label_4">
               <property name="text">
@@ -97,34 +121,30 @@
               </property>
              </widget>
             </item>
-            <item row="3" column="0">
-             <widget class="QCheckBox" name="forceCloseCheckBox">
-              <property name="text">
-               <string>Forçar fecho geometria</string>
-              </property>
-             </widget>
-            </item>
-            <item row="6" column="0">
+            <item row="7" column="0">
              <widget class="QCheckBox" name="caliasCheckBox">
               <property name="text">
                <string>Alias p / Códigos</string>
               </property>
              </widget>
             </item>
-            <item row="5" column="2">
+            <item row="7" column="2">
+             <widget class="QgsFileWidget" name="aliasQgsFileWidget">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="storageMode">
+               <enum>QgsFileWidget::GetFile</enum>
+              </property>
+             </widget>
+            </item>
+            <item row="6" column="2">
              <widget class="QgsFileWidget" name="mapQgsFileWidget">
               <property name="enabled">
                <bool>false</bool>
               </property>
               <property name="storageMode">
                <enum>QgsFileWidget::GetDirectory</enum>
-              </property>
-             </widget>
-            </item>
-            <item row="5" column="0">
-             <widget class="QCheckBox" name="cmapCheckBox">
-              <property name="text">
-               <string>Mapeamento personalizado</string>
               </property>
              </widget>
             </item>
@@ -135,30 +155,20 @@
               </property>
              </widget>
             </item>
-            <item row="1" column="0" colspan="3">
-             <widget class="QCheckBox" name="forceGeomCheckBox">
+            <item row="3" column="0">
+             <widget class="QCheckBox" name="forceCloseCheckBox">
               <property name="text">
-               <string>Forçar dimensões geometria</string>
+               <string>Forçar fecho geometria</string>
               </property>
              </widget>
-            </item>
-            <item row="6" column="2">
-             <widget class="QgsFileWidget" name="aliasQgsFileWidget">
-              <property name="enabled">
-               <bool>false</bool>
-              </property>
-              <property name="storageMode">
-               <enum>QgsFileWidget::GetFile</enum>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="2">
-             <widget class="QComboBox" name="fieldsComboBox"/>
             </item>
             <item row="4" column="0">
-             <widget class="QCheckBox" name="overwriteLNCheckBox">
+             <widget class="QCheckBox" name="cellHeaderOrigin">
               <property name="text">
-               <string>Mapear com nome camada</string>
+               <string>Aproveitar apenas a origem das células CAD</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
Este PR acrescenta a possibilidade de aproveitar apenas a origem das cell headers do desenhos DGN e DGNv8.

Depende do [PR#5664](https://github.com/OSGeo/gdal/pull/5664) no repositório GDAL.

### Estado atual

Quando existem cell headers, como no exemplo abaixo, todas as geometrias são importadas como um feature independente.
![Screenshot from 2022-05-03 19-27-16](https://user-images.githubusercontent.com/163681/166573909-816db850-d2bc-410e-a896-f31bc1b73d6d.png)

Com este PR, fica disponível uma opção adicional para só se importar a origem da cell header.
![Screenshot from 2022-05-03 18-45-59](https://user-images.githubusercontent.com/163681/166574035-afddea25-a0ac-4a8e-a3ac-59c03ae8cc47.png)

Com esta opção ativada, só um feature (com a geometria ponto) é aproveitada.

O mesmo DGN, processao com esta opção, dará como resultado:
![Screenshot from 2022-05-03 22-28-22](https://user-images.githubusercontent.com/163681/166574129-46677214-1067-4262-bfc8-6183cbfdaf7f.png)

Os tanques de água, vértices geodésicos, postes de eletricidade, etc, são importados como um único ponto e com os devidos atributos, no campo ulink.
