### PR TITLE
Permite correr o plugin com QGIS baseado no Qt5 ou Qt6

### DIFF
--- a/plugin/Makefile
+++ b/plugin/Makefile
@@ -89,9 +89,9 @@ EXTRAS = metadata.txt icon.png carttop.xml validation_rules.sql validation_setup
 
 EXTRA_DIRS =
 
-COMPILED_RESOURCE_FILES = resources.py
+COMPILED_RESOURCE_FILES = resources5.py resources6.py
 
-PEP8EXCLUDE=resources.py,ui
+PEP8EXCLUDE=resources5.py,resources6.py,ui
 
 
 #################################################
@@ -110,8 +110,11 @@ default: compile
 
 compile: $(COMPILED_RESOURCE_FILES)
 
-%.py : %.qrc $(RESOURCES_SRC)
-	pyrcc5 -o $*.py  $<
+%5.py : %.qrc $(RESOURCES_SRC)
+	pyrcc5 -o $*5.py  $<
+
+%6.py : %.qrc $(RESOURCES_SRC)
+	pyside6-rcc -o $*6.py  $<
 
 %.qm : %.ts
 	$(LRELEASE) $<

--- a/plugin/convert_dialog.py
+++ b/plugin/convert_dialog.py
@@ -27,13 +27,13 @@ import json
 from enum import Enum
 from pathlib import Path
 
-from PyQt5 import uic
-from PyQt5.QtWidgets import QDialog, QProgressDialog, QMessageBox, QAbstractItemView, QDialogButtonBox, QStyle
-from PyQt5.QtCore import Qt, QThread, pyqtSlot, pyqtSignal, QVariant
-from PyQt5.QtGui import QIntValidator, QStandardItemModel, QStandardItem
+from qgis.PyQt import uic
+from qgis.PyQt.QtWidgets import QDialog, QProgressDialog, QMessageBox, QAbstractItemView, QDialogButtonBox, QStyle
+from qgis.PyQt.QtCore import Qt, QThread, pyqtSlot, pyqtSignal, QVariant
+from qgis.PyQt.QtGui import QIntValidator, QStandardItemModel, QStandardItem
+from qgis.gui import QgsFileWidget
 
 from qgis.core import QgsProject, QgsVectorLayer, QgsDataSourceUri, QgsCoordinateReferenceSystem
-from qgis.gui import QgsFileWidget
 
 from osgeo import gdal
 from osgeo import ogr
@@ -57,7 +57,7 @@ class ConvertDialog(QDialog, FORM_CLASS):
 
         self.iface = iface
         self.buttonBox.button(
-            QDialogButtonBox.Ok).clicked.connect(self.process)
+            QDialogButtonBox.StandardButton.Ok).clicked.connect(self.process)
 
         self.nddCombo.addItems(['ndd1', 'ndd2'])
 
@@ -70,10 +70,10 @@ class ConvertDialog(QDialog, FORM_CLASS):
         self.def_config = dc
 
         if not self.initialized:
-            self.buttonBox.button(QDialogButtonBox.Cancel).setText("Fechar")
-            self.buttonBox.button(QDialogButtonBox.Cancel).setIcon(self.style().standardIcon(QStyle.SP_DialogCancelButton))
-            self.buttonBox.button(QDialogButtonBox.Ok).setText("Converter")
-            self.buttonBox.button(QDialogButtonBox.Ok).setIcon(self.style().standardIcon(QStyle.SP_DialogOkButton))
+            self.buttonBox.button(QDialogButtonBox.StandardButton.Cancel).setText("Fechar")
+            self.buttonBox.button(QDialogButtonBox.StandardButton.Cancel).setIcon(self.style().standardIcon(QStyle.StandardPixmap.SP_DialogCancelButton))
+            self.buttonBox.button(QDialogButtonBox.StandardButton.Ok).setText("Converter")
+            self.buttonBox.button(QDialogButtonBox.StandardButton.Ok).setIcon(self.style().standardIcon(QStyle.StandardPixmap.SP_DialogOkButton))
             
             self.fillDataSources()
 
@@ -89,9 +89,9 @@ class ConvertDialog(QDialog, FORM_CLASS):
         if self.convertProcess is not None and self.convertProcess.running is True:
             self.convertProcess.cancel = True
             # self.progressBar.setVisible(False)
-            # self.buttonBox.button(QDialogButtonBox.Ok).setEnabled(True)
-            # self.buttonBox.button(QDialogButtonBox.Cancel).setText("Fechar")
-            # self.buttonBox.button(QDialogButtonBox.Cancel).setIcon(self.style().standardIcon(QStyle.SP_DialogCancelButton))
+            # self.buttonBox.button(QDialogButtonBox.StandardButton.Ok).setEnabled(True)
+            # self.buttonBox.button(QDialogButtonBox.StandardButton.Cancel).setText("Fechar")
+            # self.buttonBox.button(QDialogButtonBox.StandardButton.Cancel).setIcon(self.style().standardIcon(QStyle.StandardPixmap.SP_DialogCancelButton))
         else:
             self.plainTextEdit.clear()
             super(ConvertDialog, self).reject()
@@ -208,9 +208,9 @@ class ConvertDialog(QDialog, FORM_CLASS):
 
     def finishedConvert(self):
         self.progressBar.setVisible(False)
-        self.buttonBox.button(QDialogButtonBox.Ok).setEnabled(True)
-        self.buttonBox.button(QDialogButtonBox.Cancel).setText("Fechar")
-        self.buttonBox.button(QDialogButtonBox.Cancel).setIcon(self.style().standardIcon(QStyle.SP_DialogCancelButton))
+        self.buttonBox.button(QDialogButtonBox.StandardButton.Ok).setEnabled(True)
+        self.buttonBox.button(QDialogButtonBox.StandardButton.Cancel).setText("Fechar")
+        self.buttonBox.button(QDialogButtonBox.StandardButton.Cancel).setIcon(self.style().standardIcon(QStyle.StandardPixmap.SP_DialogCancelButton))
 
         self.convertProcess = None
 
@@ -253,9 +253,9 @@ class ConvertDialog(QDialog, FORM_CLASS):
 
             self.iface.messageBar().pushMessage("Converter dados.")
             self.convertProcess.start()
-            self.buttonBox.button(QDialogButtonBox.Ok).setEnabled(False)
-            self.buttonBox.button(QDialogButtonBox.Cancel).setText("Cancelar")
-            self.buttonBox.button(QDialogButtonBox.Cancel).setIcon(self.style().standardIcon(QStyle.SP_DialogDiscardButton))
+            self.buttonBox.button(QDialogButtonBox.StandardButton.Ok).setEnabled(False)
+            self.buttonBox.button(QDialogButtonBox.StandardButton.Cancel).setText("Cancelar")
+            self.buttonBox.button(QDialogButtonBox.StandardButton.Cancel).setIcon(self.style().standardIcon(QStyle.StandardPixmap.SP_DialogDiscardButton))
         else:
             self.writeText('[Aviso] Configuração inválida')
 

--- a/plugin/main_dialog.py
+++ b/plugin/main_dialog.py
@@ -28,10 +28,10 @@ import json
 from enum import Enum
 from pathlib import Path
 
-from PyQt5 import uic
-from PyQt5.QtWidgets import QDialog, QProgressDialog, QMessageBox, QAbstractItemView
-from PyQt5.QtCore import Qt, QThread, pyqtSlot, pyqtSignal, QVariant
-from PyQt5.QtGui import QIntValidator, QStandardItemModel, QStandardItem
+from qgis.PyQt import uic
+from qgis.PyQt.QtWidgets import QDialog, QProgressDialog, QMessageBox, QAbstractItemView
+from qgis.PyQt.QtCore import Qt, QThread, pyqtSlot, pyqtSignal, QVariant
+from qgis.PyQt.QtGui import QIntValidator, QStandardItemModel, QStandardItem
 
 from qgis.core import QgsProject, QgsVectorLayer, QgsDataSourceUri, QgsStyle, QgsEditorWidgetSetup, QgsLayerTreeGroup, QgsLayerTreeLayer, QgsCoordinateReferenceSystem
 from qgis.utils import iface
@@ -59,7 +59,7 @@ class MainDialog(QDialog, FORM_CLASS):
         self.setupUi(self)
 
         self.iface = iface
-        self.treeView.setSelectionMode(QAbstractItemView.MultiSelection)
+        self.treeView.setSelectionMode(QAbstractItemView.SelectionMode.MultiSelection)
         self.exportFormat.addItems(
             ['Shapefile', 'GeoJSON', 'GeoPackage', 'Projeto QGIS'])
         self.exportEncoding.addItems(

--- a/plugin/metadata.txt
+++ b/plugin/metadata.txt
@@ -2,20 +2,23 @@
 name=RecartDGT
 qgisMinimumVersion=3.14
 description=Convert, import, export cartography datasets based on CartTop specification
-version=v1.5
+version=1.6.0
 author=Geomaster
 email=geral@geomaster.pt
 
 about=Creates QGIS projects from CartTop datasets stored on Postgresql; export CartTop datasets to GPKG, SHP and GeoJSON; validates CartTop rules; convert old DGN/DWG MNT datasets to CartTop (GDAL > 3.1 is required). CartTop is the official specification for cartographic data in Portugal.
 
-tracker=
-repository=
+tracker=https://github.com/dgterritorio/recart-plugin/issues
+repository=https://github.com/dgterritorio/recart-plugin
+
+changelog=version 1.6.0: Suportar Qt6
 
 tags=dgt,geomaster
 
-homepage=https://geomaster.pt
+homepage=https://www.dgterritorio.gov.pt/
 category=Plugins
 icon=icon.png
 
-experimental=True
+experimental=False
 deprecated=False
+supportsQt6=True

--- a/plugin/qgis_configs.py
+++ b/plugin/qgis_configs.py
@@ -18,8 +18,8 @@
  *                                                                         *
  ***************************************************************************/
 """
-from PyQt5.QtCore import QSettings
-from PyQt5.QtWidgets import QInputDialog, QMessageBox, QLineEdit
+from qgis.PyQt.QtCore import QSettings
+from qgis.PyQt.QtWidgets import QInputDialog, QMessageBox, QLineEdit
 from qgis.core import QgsApplication, QgsAuthMethodConfig
 
 def listDataSources():

--- a/plugin/recartDGT.py
+++ b/plugin/recartDGT.py
@@ -21,16 +21,20 @@
 """
 import os.path
 
-from PyQt5.QtCore import QSettings, QTranslator, qVersion, QCoreApplication
-from PyQt5.QtGui import QIcon
-from PyQt5.QtWidgets import QAction
+from qgis.PyQt.QtCore import QT_VERSION_STR, QSettings, QTranslator, qVersion, QCoreApplication
+from qgis.PyQt.QtGui import QIcon
+from qgis.PyQt.QtWidgets import QAction
 
 from .main_dialog import MainDialog
 from .convert_dialog import ConvertDialog
 from .validation_dialog import ValidationDialog
 
-# Initialize Qt resources from file resources.py
-from .resources import *
+# Initialize Qt resources from file resources*.py
+QT_MAJOR_VERSION = int(QT_VERSION_STR.split(".")[0])
+if QT_MAJOR_VERSION < 6:
+    from .resources5 import *
+else:
+    from .resources6 import *
 
 
 class recartDGT:

--- a/plugin/ui/convert_dialog.ui
+++ b/plugin/ui/convert_dialog.ui
@@ -201,9 +201,6 @@
            <property name="storageMode">
             <enum>QgsFileWidget::GetDirectory</enum>
            </property>
-           <property name="options">
-            <set>QFileDialog::ShowDirsOnly</set>
-           </property>
           </widget>
          </item>
          <item row="4" column="0" colspan="8">
@@ -344,7 +341,7 @@
   </connection>
   <connection>
    <sender>connCombo</sender>
-   <signal>currentIndexChanged(QString)</signal>
+   <signal>currentTextChanged(QString)</signal>
    <receiver>ConvertDialog</receiver>
    <slot>changeConn(QString)</slot>
    <hints>
@@ -375,4 +372,10 @@
    </hints>
   </connection>
  </connections>
+ <slots>
+  <slot>changeInputFile(QString)</slot>
+  <slot>changeCustomMap(int)</slot>
+  <slot>changeAliasMap(int)</slot>
+  <slot>changeConn(QString)</slot>
+ </slots>
 </ui>

--- a/plugin/ui/main_dialog.ui
+++ b/plugin/ui/main_dialog.ui
@@ -200,7 +200,7 @@
  <connections>
   <connection>
    <sender>connCombo</sender>
-   <signal>currentIndexChanged(QString)</signal>
+   <signal>currentTextChanged(QString)</signal>
    <receiver>MainDialog</receiver>
    <slot>changeConn(QString)</slot>
    <hints>
@@ -264,7 +264,7 @@
   </connection>
   <connection>
    <sender>exportFormat</sender>
-   <signal>currentIndexChanged(QString)</signal>
+   <signal>currentTextChanged(QString)</signal>
    <receiver>MainDialog</receiver>
    <slot>onChangeFormat(QString)</slot>
    <hints>
@@ -279,4 +279,11 @@
    </hints>
   </connection>
  </connections>
+ <slots>
+  <slot>changeConn(QString)</slot>
+  <slot>doLoadLayers()</slot>
+  <slot>doExportLayers()</slot>
+  <slot>selectAll(int)</slot>
+  <slot>onChangeFormat(QString)</slot>
+ </slots>
 </ui>

--- a/plugin/ui/validation_dialog.ui
+++ b/plugin/ui/validation_dialog.ui
@@ -226,7 +226,7 @@
   </connection>
   <connection>
    <sender>connCombo</sender>
-   <signal>currentIndexChanged(QString)</signal>
+   <signal>currentTextChanged(QString)</signal>
    <receiver>ValidationDialog</receiver>
    <slot>changeConn(QString)</slot>
    <hints>
@@ -306,7 +306,7 @@
   </connection>
   <connection>
    <sender>schemaName</sender>
-   <signal>currentIndexChanged(QString)</signal>
+   <signal>currentTextChanged(QString)</signal>
    <receiver>ValidationDialog</receiver>
    <slot>changeSchema(QString)</slot>
    <hints>
@@ -321,4 +321,12 @@
    </hints>
   </connection>
  </connections>
+ <slots>
+  <slot>changeConn(QString)</slot>
+  <slot>validate3dChange(bool)</slot>
+  <slot>setupRules()</slot>
+  <slot>exportRel()</slot>
+  <slot>validateAllChange(bool)</slot>
+  <slot>changeSchema(QString)</slot>
+ </slots>
 </ui>

--- a/plugin/validation_dialog.py
+++ b/plugin/validation_dialog.py
@@ -24,10 +24,10 @@ import re
 
 from datetime import datetime
 
-from PyQt5 import uic
-from PyQt5.QtWidgets import QDialog, QDialogButtonBox, QMessageBox, QHeaderView, QCheckBox, QStyle
-from PyQt5.QtCore import Qt, QThread, pyqtSlot, pyqtSignal
-from PyQt5.QtGui import QStandardItemModel, QStandardItem, QFont
+from qgis.PyQt import uic
+from qgis.PyQt.QtWidgets import QDialog, QDialogButtonBox, QMessageBox, QHeaderView, QCheckBox, QStyle
+from qgis.PyQt.QtCore import Qt, QThread, pyqtSlot, pyqtSignal
+from qgis.PyQt.QtGui import QStandardItemModel, QStandardItem, QFont
 
 from qgis.core import QgsProject, QgsVectorLayer, QgsStyle, QgsPrintLayout, QgsLayoutExporter, QgsLayoutItem, QgsLayoutItemTextTable, QgsLayoutTableColumn, QgsLayoutFrame, QgsLayoutSize, QgsLayoutPoint, QgsUnitTypes, QgsLayoutItemPage, QgsLayoutItemLabel, QgsCoordinateReferenceSystem
 from qgis.utils import iface
@@ -53,10 +53,10 @@ class ValidationDialog(QDialog, FORM_CLASS):
 
         self.iface = iface
         self.buttonBox.button(
-            QDialogButtonBox.Ok).clicked.connect(self.process)
+            QDialogButtonBox.StandardButton.Ok).clicked.connect(self.process)
 
         self.buttonBox.button(
-            QDialogButtonBox.Reset).clicked.connect(self.reset)
+            QDialogButtonBox.StandardButton.Reset).clicked.connect(self.reset)
 
         self.comboBox.addItems(['NdD1', 'NdD2'])
         self.versaocomboBox.addItems(['V 1.1', 'V 1.1.1', 'V 1.1.2'])
@@ -77,13 +77,13 @@ class ValidationDialog(QDialog, FORM_CLASS):
         self.updateProcess = None
 
         if not self.initialized:
-            self.buttonBox.button(QDialogButtonBox.Cancel).setText("Fechar")
-            self.buttonBox.button(QDialogButtonBox.Cancel).setIcon(self.style().standardIcon(QStyle.SP_DialogCancelButton))
-            self.buttonBox.button(QDialogButtonBox.Ok).setText("Validar")
-            self.buttonBox.button(QDialogButtonBox.Ok).setIcon(self.style().standardIcon(QStyle.SP_DialogOkButton))
-            self.buttonBox.button(QDialogButtonBox.Ok).setEnabled(True)
+            self.buttonBox.button(QDialogButtonBox.StandardButton.Cancel).setText("Fechar")
+            self.buttonBox.button(QDialogButtonBox.StandardButton.Cancel).setIcon(self.style().standardIcon(QStyle.StandardPixmap.SP_DialogCancelButton))
+            self.buttonBox.button(QDialogButtonBox.StandardButton.Ok).setText("Validar")
+            self.buttonBox.button(QDialogButtonBox.StandardButton.Ok).setIcon(self.style().standardIcon(QStyle.StandardPixmap.SP_DialogOkButton))
+            self.buttonBox.button(QDialogButtonBox.StandardButton.Ok).setEnabled(True)
 
-            self.tableView.horizontalHeader().setSectionResizeMode(QHeaderView.Interactive)
+            self.tableView.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeMode.Interactive)
             self.tableView.horizontalHeader().setStretchLastSection(True)
             self.tableView.setVisible(False)
 
@@ -104,9 +104,9 @@ class ValidationDialog(QDialog, FORM_CLASS):
             self.isRunning = False
         elif self.validateProcess is not None:
             self.validateProcess.setCancel(True)
-            self.buttonBox.button(QDialogButtonBox.Cancel).setText("Fechar")
-            self.buttonBox.button(QDialogButtonBox.Cancel).setIcon(self.style().standardIcon(QStyle.SP_DialogCancelButton))
-            self.buttonBox.button(QDialogButtonBox.Ok).setEnabled(True)
+            self.buttonBox.button(QDialogButtonBox.StandardButton.Cancel).setText("Fechar")
+            self.buttonBox.button(QDialogButtonBox.StandardButton.Cancel).setIcon(self.style().standardIcon(QStyle.StandardPixmap.SP_DialogCancelButton))
+            self.buttonBox.button(QDialogButtonBox.StandardButton.Ok).setEnabled(True)
             self.isRunning = False
         else:
             self.plainTextEdit.clear()
@@ -506,8 +506,8 @@ class ValidationDialog(QDialog, FORM_CLASS):
     def finishedValidate(self):
         self.updateProcess.setStop(True)
         self.updateTable()
-        self.buttonBox.button(QDialogButtonBox.Cancel).setText("Fechar")
-        self.buttonBox.button(QDialogButtonBox.Cancel).setIcon(self.style().standardIcon(QStyle.SP_DialogCancelButton))
+        self.buttonBox.button(QDialogButtonBox.StandardButton.Cancel).setText("Fechar")
+        self.buttonBox.button(QDialogButtonBox.StandardButton.Cancel).setIcon(self.style().standardIcon(QStyle.StandardPixmap.SP_DialogCancelButton))
 
         if not self.validateProcess.cancel is True:
             conString = qgis_configs.getConnString(self, self.getConnection())
@@ -521,14 +521,14 @@ class ValidationDialog(QDialog, FORM_CLASS):
         else:
             self.isRunning = False
             self.progressBar.setVisible(False)
-            self.buttonBox.button(QDialogButtonBox.Ok).setEnabled(True)
+            self.buttonBox.button(QDialogButtonBox.StandardButton.Ok).setEnabled(True)
 
         self.validateProcess = None
 
     def finishedAddLayers(self):
         self.isRunning = False
         self.progressBar.setVisible(False)
-        self.buttonBox.button(QDialogButtonBox.Ok).setEnabled(True)
+        self.buttonBox.button(QDialogButtonBox.StandardButton.Ok).setEnabled(True)
 
         self.writeText("Terminada a validação")
 
@@ -550,14 +550,14 @@ class ValidationDialog(QDialog, FORM_CLASS):
             self.writeText("\tA executar validações ...\n")
             self.validateProcess.start()
 
-            self.buttonBox.button(QDialogButtonBox.Cancel).setText("Cancelar")
-            self.buttonBox.button(QDialogButtonBox.Cancel).setIcon(self.style().standardIcon(QStyle.SP_DialogDiscardButton))
-            self.buttonBox.button(QDialogButtonBox.Ok).setEnabled(False)
+            self.buttonBox.button(QDialogButtonBox.StandardButton.Cancel).setText("Cancelar")
+            self.buttonBox.button(QDialogButtonBox.StandardButton.Cancel).setIcon(self.style().standardIcon(QStyle.StandardPixmap.SP_DialogDiscardButton))
+            self.buttonBox.button(QDialogButtonBox.StandardButton.Ok).setEnabled(False)
             self.createProcess = None
         elif self.createProcess is not None:
-            self.buttonBox.button(QDialogButtonBox.Cancel).setText("Fechar")
-            self.buttonBox.button(QDialogButtonBox.Cancel).setIcon(self.style().standardIcon(QStyle.SP_DialogCancelButton))
-            self.buttonBox.button(QDialogButtonBox.Ok).setEnabled(True)
+            self.buttonBox.button(QDialogButtonBox.StandardButton.Cancel).setText("Fechar")
+            self.buttonBox.button(QDialogButtonBox.StandardButton.Cancel).setIcon(self.style().standardIcon(QStyle.StandardPixmap.SP_DialogCancelButton))
+            self.buttonBox.button(QDialogButtonBox.StandardButton.Ok).setEnabled(True)
             self.progressBar.setVisible(False)
             self.createProcess = None
 
@@ -644,9 +644,9 @@ class ValidationDialog(QDialog, FORM_CLASS):
             self.writeText("\tA criar estrutura de validação ...")
             self.isRunning = True
             self.createProcess.start()
-            self.buttonBox.button(QDialogButtonBox.Cancel).setText("Cancelar")
-            self.buttonBox.button(QDialogButtonBox.Cancel).setIcon(self.style().standardIcon(QStyle.SP_DialogDiscardButton))
-            self.buttonBox.button(QDialogButtonBox.Ok).setEnabled(False)
+            self.buttonBox.button(QDialogButtonBox.StandardButton.Cancel).setText("Cancelar")
+            self.buttonBox.button(QDialogButtonBox.StandardButton.Cancel).setIcon(self.style().standardIcon(QStyle.StandardPixmap.SP_DialogDiscardButton))
+            self.buttonBox.button(QDialogButtonBox.StandardButton.Ok).setEnabled(False)
         else:
             self.writeText('[Aviso] Configuração inválida')
 


### PR DESCRIPTION
O base do QGIS está a mudar de Qt5 para Qt6. Já estão a ser produzidas versões de teste sobre o Qt6.

A mudança implica a atualização dos plugins mais antigos, para suportarem Qt6.

Este PR torna o plugin compatível com o QGIS baseado no Qt5 ou Qt6.

