### PR TITLE
Prevenir erro esporádico na ação de publicação do github

### DIFF
--- a/.github/workflows/make-plugin-release.yml
+++ b/.github/workflows/make-plugin-release.yml
@@ -24,6 +24,7 @@ jobs:
           make zip
       - name: Automatic push changes
         run: |
+          git config --global user.email "jgr@geomaster.pt"
           git config --global user.name ${{github.actor}}
           git stash
           git checkout main


### PR DESCRIPTION
Por vezes, ao publicar uma nova release (com a ação do github), dá o seguinte erro:

```text
Run git config --global user.name jgrocha
Saved working directory and index state WIP on (no branch): 47bcd82 Estilos consoante a versão do Recart (p/ 1.1.2, 2.0.1 e 2.0.2) (#64)
Switched to a new branch 'main'
branch 'main' set up to track 'origin/main'.
On branch main
Your branch is up to date with 'origin/main'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   plugin/metadata.txt

no changes added to commit (use "git add" and/or "git commit -a")
Author identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: unable to auto-detect email address (got 'runner@runnervmf4ws1.(none)')
Error: Process completed with exit code 128.
```

Submetendo outra tag, corre sem problema. Parece algo esporádico.

Para prevenir, este PR define o user.email na ação. Falta testar e ver se corre sempre bem.